### PR TITLE
feat: introduce objects into api and refactor preferences

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ const { Knock } = require("@knocklabs/node");
 const knockClient = new Knock("sk_12345");
 
 // Set an entire preference set
-await knockClient.preferences.set("jhammond", {
+await knockClient.users.setPreferences("jhammond", {
   channel_types: { email: true, sms: false },
   workflows: {
     "dinosaurs-loose": {
@@ -103,18 +103,7 @@ await knockClient.preferences.set("jhammond", {
 });
 
 // Retrieve a whole preference set
-const preferences = await knockClient.preferences.get("jhammond");
-
-// Granular preference setting for channel types
-await knockClient.preferences.setChannelType("jhammond", "email", false);
-
-// Granular preference setting for workflows
-await knockClient.preferences.setWorkflow("jhammond", "dinosaurs-loose", {
-  channel_types: {
-    email: true,
-    in_app_feed: false,
-  },
-});
+const preferences = await knockClient.users.getPreferences("jhammond");
 ```
 
 ### Getting and setting channel data

--- a/src/common/interfaces.ts
+++ b/src/common/interfaces.ts
@@ -16,3 +16,16 @@ export interface UnprocessableEntityError {
   type: string;
   field: string;
 }
+
+// Channel types supported in Knock
+// TODO: it would be great to pull this in from an external location
+export type ChannelType = "email" | "in_app_feed" | "sms" | "push" | "chat";
+
+export type CommonMetadata = Record<string, any>;
+
+export interface ChannelData<T = CommonMetadata> {
+  channel_id: string;
+  data: T;
+}
+
+export interface SetChannelDataProperties {}

--- a/src/knock.ts
+++ b/src/knock.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosError, AxiosResponse, AxiosInstance } from "axios";
+import axios, { AxiosResponse, AxiosInstance } from "axios";
 import { version } from "../package.json";
 
 import {
@@ -14,6 +14,8 @@ import { Users } from "./resources/users";
 import { Preferences } from "./resources/preferences";
 import { Workflows } from "./resources/workflows";
 import { TriggerWorkflowProperties } from "./resources/workflows/interfaces";
+import { BulkOperations } from "./resources/bulk_operations";
+import { Objects } from "./resources/objects";
 
 const DEFAULT_HOSTNAME = "https://api.knock.app";
 
@@ -21,9 +23,12 @@ class Knock {
   readonly host: string;
   private readonly client: AxiosInstance;
 
+  // Service accessors
   readonly users = new Users(this);
   readonly preferences = new Preferences(this);
   readonly workflows = new Workflows(this);
+  readonly bulkOperations = new BulkOperations(this);
+  readonly objects = new Objects(this);
 
   constructor(readonly key?: string, readonly options: KnockOptions = {}) {
     if (!key) {
@@ -102,9 +107,9 @@ class Knock {
     }
   }
 
-  handleErrorResponse(path: string, { response }: AxiosError) {
-    if (response) {
-      const { status, data, headers } = response;
+  handleErrorResponse(path: string, error: any) {
+    if (axios.isAxiosError(error) && error.response) {
+      const { status, data, headers } = error.response;
       const requestID = headers["X-Request-ID"];
 
       switch (status) {

--- a/src/resources/bulk_operations/index.ts
+++ b/src/resources/bulk_operations/index.ts
@@ -1,0 +1,11 @@
+import { Knock } from "../../knock";
+import { BulkOperation } from "../bulk_operations/interfaces";
+
+export class BulkOperations {
+  constructor(readonly knock: Knock) {}
+
+  async get(id: string): Promise<BulkOperation> {
+    const { data } = await this.knock.get(`/v1/bulk_operations/${id}`);
+    return data;
+  }
+}

--- a/src/resources/bulk_operations/interfaces.ts
+++ b/src/resources/bulk_operations/interfaces.ts
@@ -1,0 +1,12 @@
+export interface BulkOperation {
+  id: string;
+  name: string;
+  status: "queued" | "processing" | "completed" | "failed";
+  processed_rows: number;
+  estimated_total_rows: number;
+  started_at?: string;
+  completed_at?: string;
+  failed_at?: string;
+  inserted_at: string;
+  updated_at: string;
+}

--- a/src/resources/objects/index.ts
+++ b/src/resources/objects/index.ts
@@ -1,0 +1,97 @@
+import {
+  ChannelData,
+  CommonMetadata,
+  SetChannelDataProperties,
+} from "../../common/interfaces";
+import { Knock } from "../../knock";
+import { BulkSetObjectOption, Object, SetObjectProperties } from "./interfaces";
+import { BulkOperation } from "../bulk_operations/interfaces";
+
+export class Objects {
+  constructor(readonly knock: Knock) {}
+
+  async get<T = CommonMetadata>(
+    collection: string,
+    id: string,
+  ): Promise<Object<T>> {
+    const { data } = await this.knock.get(`/v1/objects/${collection}/${id}`);
+    return data;
+  }
+
+  async set<T = CommonMetadata>(
+    collection: string,
+    id: string,
+    properties: SetObjectProperties,
+  ): Promise<Object<T>> {
+    const { data } = await this.knock.put(
+      `/v1/objects/${collection}/${id}`,
+      properties,
+    );
+    return data;
+  }
+
+  async bulkSet(
+    collection: string,
+    objects: BulkSetObjectOption[],
+  ): Promise<BulkOperation> {
+    const attrs = { objects };
+
+    const { data } = await this.knock.post(
+      `/v1/objects/${collection}/bulk/set`,
+      attrs,
+    );
+
+    return data;
+  }
+
+  async delete(collection: string, id: string): Promise<null> {
+    const { data } = await this.knock.delete(`/v1/objects/${collection}/${id}`);
+    return data;
+  }
+
+  async bulkDelete(
+    collection: string,
+    objectIds: string[],
+  ): Promise<BulkOperation> {
+    const attrs = {
+      object_ids: objectIds,
+    };
+
+    const { data } = await this.knock.post(
+      `/v1/objects/${collection}/bulk/delete`,
+      attrs,
+    );
+
+    return data;
+  }
+
+  // Channel data
+
+  async getChannelData<T = CommonMetadata>(
+    collection: string,
+    id: string,
+    channelId: string,
+  ): Promise<ChannelData<T>> {
+    const { data } = await this.knock.get(
+      `/v1/objects/${collection}/${id}/channel_data/${channelId}`,
+    );
+
+    return data;
+  }
+
+  async setChannelData<T = CommonMetadata>(
+    collection: string,
+    id: string,
+    channelId: string,
+    channelData: SetChannelDataProperties,
+  ): Promise<ChannelData<T>> {
+    const attrs = { data: channelData };
+
+    const { data } = await this.knock.put(
+      `/v1/objects/${collection}/${id}/channel_data/${channelId}`,
+      attrs,
+    );
+
+    return data;
+  }
+}

--- a/src/resources/objects/interfaces.ts
+++ b/src/resources/objects/interfaces.ts
@@ -1,0 +1,25 @@
+import { CommonMetadata } from "../../common/interfaces";
+
+export interface ObjectRef {
+  collection: string;
+  id: string;
+}
+
+export interface Object<T = CommonMetadata> {
+  id: string;
+  collection: string;
+  properties: T;
+  created_at?: string;
+  updated_at: string;
+}
+
+export interface SetObjectProperties {
+  name?: string;
+  [key: string]: any;
+}
+
+export interface BulkSetObjectOption {
+  id: string;
+  name?: string;
+  [key: string]: any;
+}

--- a/src/resources/preferences/helpers.ts
+++ b/src/resources/preferences/helpers.ts
@@ -1,0 +1,11 @@
+import { WorkflowPreferenceSetting } from "./interfaces";
+
+export function buildUpdateParam(param: WorkflowPreferenceSetting) {
+  if (typeof param === "object") {
+    return param;
+  }
+
+  return { subscribed: param };
+}
+
+export const DEFAULT_PREFERENCE_SET_ID = "default";

--- a/src/resources/preferences/index.ts
+++ b/src/resources/preferences/index.ts
@@ -1,6 +1,6 @@
+import { ChannelType } from "../../common/interfaces";
 import { Knock } from "../../knock";
 import {
-  ChannelType,
   ChannelTypePreferences,
   WorkflowPreferenceSetting,
   WorkflowPreferences,
@@ -9,144 +9,131 @@ import {
   PreferenceSet,
 } from "./interfaces";
 
-const DEFAULT_PREFERENCE_SET_ID = "default";
-
-function buildUpdateParam(param: WorkflowPreferenceSetting) {
-  if (typeof param === "object") {
-    return param;
-  }
-
-  return { subscribed: param };
-}
-
+// Deprecated all of the methods in this to be removed in `0.5.0`
 export class Preferences {
   constructor(readonly knock: Knock) {}
 
+  /**
+   * @deprecated Use `users.getAllPreferences` instead
+   */
   async getAll(userId: string): Promise<PreferenceSet[]> {
-    const { data } = await this.knock.get(`/v1/users/${userId}/preferences`);
-    return data;
+    return this.knock.users.getAllPreferences(userId);
   }
 
+  /**
+   * @deprecated Use `users.getPreferences` instead
+   */
   async get(
     userId: string,
     options: PreferenceOptions = {},
   ): Promise<PreferenceSet> {
-    const preferenceSetId = options.preferenceSet || DEFAULT_PREFERENCE_SET_ID;
-
-    const { data } = await this.knock.get(
-      `/v1/users/${userId}/preferences/${preferenceSetId}`,
-    );
-
-    return data;
+    return this.knock.users.getPrefences(userId, options);
   }
 
+  /**
+   * @deprecated Use `users.setPreferences` instead
+   */
   async set(
     userId: string,
     preferenceSet: SetPreferencesProperties,
     options: PreferenceOptions = {},
   ): Promise<PreferenceSet> {
-    const preferenceSetId = options.preferenceSet || DEFAULT_PREFERENCE_SET_ID;
-
-    const { data } = await this.knock.put(
-      `/v1/users/${userId}/preferences/${preferenceSetId}`,
-      preferenceSet,
-    );
-
-    return data;
+    return this.knock.users.setPreferences(userId, preferenceSet, options);
   }
 
+  /**
+   * @deprecated Use `users.setChannelTypesPreferences` instead
+   */
   async setChannelTypes(
     userId: string,
     channelTypePreferences: ChannelTypePreferences,
     options: PreferenceOptions = {},
   ): Promise<PreferenceSet> {
-    const preferenceSetId = options.preferenceSet || DEFAULT_PREFERENCE_SET_ID;
-
-    const { data } = await this.knock.put(
-      `/v1/users/${userId}/preferences/${preferenceSetId}/channel_types`,
+    return this.knock.users.setChannelTypesPreferences(
+      userId,
       channelTypePreferences,
+      options,
     );
-
-    return data;
   }
 
+  /**
+   * @deprecated Use `users.setChannelTypePreferences` instead
+   */
   async setChannelType(
     userId: string,
     channelType: ChannelType,
     setting: boolean,
     options: PreferenceOptions = {},
   ): Promise<PreferenceSet> {
-    const preferenceSetId = options.preferenceSet || DEFAULT_PREFERENCE_SET_ID;
-
-    const {
-      data,
-    } = await this.knock.put(
-      `/v1/users/${userId}/preferences/${preferenceSetId}/channel_types/${channelType}`,
-      { subscribed: setting },
+    return this.knock.users.setChannelTypePreferences(
+      userId,
+      channelType,
+      setting,
+      options,
     );
-
-    return data;
   }
 
+  /**
+   * @deprecated Use `users.setWorkflowsPreferences` instead
+   */
   async setWorkflows(
     userId: string,
     workflowPreferences: WorkflowPreferences,
     options: PreferenceOptions = {},
   ): Promise<PreferenceSet> {
-    const preferenceSetId = options.preferenceSet || DEFAULT_PREFERENCE_SET_ID;
-
-    const { data } = await this.knock.put(
-      `/v1/users/${userId}/preferences/${preferenceSetId}/workflows`,
+    return this.knock.users.setWorkflowsPreferences(
+      userId,
       workflowPreferences,
+      options,
     );
-
-    return data;
   }
 
+  /**
+   * @deprecated Use `users.setWorkflowPreferences` instead
+   */
   async setWorkflow(
     userId: string,
     workflowKey: string,
     setting: WorkflowPreferenceSetting,
     options: PreferenceOptions = {},
   ): Promise<PreferenceSet> {
-    const preferenceSetId = options.preferenceSet || DEFAULT_PREFERENCE_SET_ID;
-
-    const { data } = await this.knock.put(
-      `/v1/users/${userId}/preferences/${preferenceSetId}/workflows/${workflowKey}`,
-      buildUpdateParam(setting),
+    return this.knock.users.setWorkflowPreferences(
+      userId,
+      workflowKey,
+      setting,
+      options,
     );
-
-    return data;
   }
 
+  /**
+   * @deprecated Use `users.setCategoriesPreferences` instead
+   */
   async setCategories(
     userId: string,
     categoryPreferences: WorkflowPreferences,
     options: PreferenceOptions = {},
   ): Promise<PreferenceSet> {
-    const preferenceSetId = options.preferenceSet || DEFAULT_PREFERENCE_SET_ID;
-
-    const { data } = await this.knock.put(
-      `/v1/users/${userId}/preferences/${preferenceSetId}/categories`,
+    return this.knock.users.setCategoriesPreferences(
+      userId,
       categoryPreferences,
+      options,
     );
-
-    return data;
   }
 
+  /**
+   * @deprecated Use `users.setCategoryPreferences` instead
+   */
   async setCategory(
     userId: string,
     categoryKey: string,
     setting: WorkflowPreferenceSetting,
     options: PreferenceOptions = {},
   ): Promise<PreferenceSet> {
-    const preferenceSetId = options.preferenceSet || DEFAULT_PREFERENCE_SET_ID;
-
-    const { data } = await this.knock.put(
-      `/v1/users/${userId}/preferences/${preferenceSetId}/categories/${categoryKey}`,
-      buildUpdateParam(setting),
+    return this.knock.users.setCategoryPreferences(
+      userId,
+      categoryKey,
+      setting,
+      options,
     );
-
-    return data;
   }
 }

--- a/src/resources/preferences/interfaces.ts
+++ b/src/resources/preferences/interfaces.ts
@@ -1,6 +1,4 @@
-// Channel types supported in Knock
-// TODO: it would be great to pull this in from an external location
-export type ChannelType = "email" | "in_app_feed" | "sms" | "push";
+import { ChannelType } from "../../common/interfaces";
 
 export type ChannelTypePreferences = {
   [K in ChannelType]: boolean;

--- a/src/resources/preferences/interfaces.ts
+++ b/src/resources/preferences/interfaces.ts
@@ -13,9 +13,9 @@ export interface WorkflowPreferences {
 }
 
 export interface SetPreferencesProperties {
-  workflows: WorkflowPreferences;
-  categories: WorkflowPreferences;
-  channel_types: ChannelTypePreferences;
+  workflows?: WorkflowPreferences;
+  categories?: WorkflowPreferences;
+  channel_types?: ChannelTypePreferences;
 }
 
 export interface PreferenceSet {

--- a/src/resources/users/index.ts
+++ b/src/resources/users/index.ts
@@ -1,10 +1,40 @@
+import {
+  ChannelData,
+  ChannelType,
+  CommonMetadata,
+} from "../../common/interfaces";
+import { BulkOperation } from "../bulk_operations/interfaces";
+import {
+  ChannelTypePreferences,
+  PreferenceOptions,
+  PreferenceSet,
+  SetPreferencesProperties,
+  WorkflowPreferences,
+  WorkflowPreferenceSetting,
+} from "../preferences/interfaces";
+import {
+  DEFAULT_PREFERENCE_SET_ID,
+  buildUpdateParam,
+} from "../preferences/helpers";
 import { Knock } from "../../knock";
-import { IdentifyProperties } from "./interfaces";
+import {
+  BulkIdentifyUser,
+  IdentifyProperties,
+  User,
+  UserFeedOptions,
+} from "./interfaces";
 
 export class Users {
   constructor(readonly knock: Knock) {}
 
-  async identify(userId: string, properties: IdentifyProperties = {}) {
+  //
+  // User management
+  //
+
+  async identify(
+    userId: string,
+    properties: IdentifyProperties = {},
+  ): Promise<User> {
     if (!userId) {
       throw new Error(
         `Incomplete arguments. At a minimum you need to specify 'userId'.`,
@@ -15,7 +45,13 @@ export class Users {
     return data;
   }
 
-  async get(userId: string) {
+  async bulkIdentify(users: BulkIdentifyUser[]): Promise<BulkOperation> {
+    const attrs = { users };
+    const { data } = await this.knock.post(`/v1/users/bulk/identify`, attrs);
+    return data;
+  }
+
+  async get(userId: string): Promise<User> {
     if (!userId) {
       throw new Error(`Incomplete arguments. You must provide a 'userId'`);
     }
@@ -24,7 +60,7 @@ export class Users {
     return data;
   }
 
-  async delete(userId: string) {
+  async delete(userId: string): Promise<null> {
     if (!userId) {
       throw new Error(`Incomplete arguments. You must provide a 'userId'`);
     }
@@ -33,7 +69,169 @@ export class Users {
     return data;
   }
 
-  async getChannelData(userId: string, channelId: string) {
+  async bulkDelete(userIds: string[]): Promise<BulkOperation> {
+    const attrs = { user_ids: userIds };
+    const { data } = await this.knock.post(`/v1/users/bulk/delete`, attrs);
+    return data;
+  }
+
+  //
+  // Feeds
+  //
+
+  async getFeed(
+    userId: string,
+    channelId: string,
+    feedOptions: UserFeedOptions = {},
+  ) {
+    const { data } = await this.knock.get(
+      `/v1/users/${userId}/feeds/${channelId}`,
+      feedOptions,
+    );
+
+    return data;
+  }
+
+  //
+  // Preferences
+  //
+
+  async getAllPreferences(userId: string) {
+    const { data } = await this.knock.get(`/v1/users/${userId}/preferences`);
+    return data;
+  }
+
+  async getPrefences(
+    userId: string,
+    options: PreferenceOptions = {},
+  ): Promise<PreferenceSet> {
+    const preferenceSetId = options.preferenceSet || DEFAULT_PREFERENCE_SET_ID;
+
+    const { data } = await this.knock.get(
+      `/v1/users/${userId}/preferences/${preferenceSetId}`,
+    );
+
+    return data;
+  }
+
+  async setPreferences(
+    userId: string,
+    preferenceSet: SetPreferencesProperties,
+    options: PreferenceOptions = {},
+  ): Promise<PreferenceSet> {
+    const preferenceSetId = options.preferenceSet || DEFAULT_PREFERENCE_SET_ID;
+
+    const { data } = await this.knock.put(
+      `/v1/users/${userId}/preferences/${preferenceSetId}`,
+      preferenceSet,
+    );
+
+    return data;
+  }
+
+  async setChannelTypesPreferences(
+    userId: string,
+    channelTypePreferences: ChannelTypePreferences,
+    options: PreferenceOptions = {},
+  ): Promise<PreferenceSet> {
+    const preferenceSetId = options.preferenceSet || DEFAULT_PREFERENCE_SET_ID;
+
+    const { data } = await this.knock.put(
+      `/v1/users/${userId}/preferences/${preferenceSetId}/channel_types`,
+      channelTypePreferences,
+    );
+
+    return data;
+  }
+
+  async setChannelTypePreferences(
+    userId: string,
+    channelType: ChannelType,
+    setting: boolean,
+    options: PreferenceOptions = {},
+  ): Promise<PreferenceSet> {
+    const preferenceSetId = options.preferenceSet || DEFAULT_PREFERENCE_SET_ID;
+
+    const {
+      data,
+    } = await this.knock.put(
+      `/v1/users/${userId}/preferences/${preferenceSetId}/channel_types/${channelType}`,
+      { subscribed: setting },
+    );
+
+    return data;
+  }
+
+  async setWorkflowsPreferences(
+    userId: string,
+    workflowPreferences: WorkflowPreferences,
+    options: PreferenceOptions = {},
+  ): Promise<PreferenceSet> {
+    const preferenceSetId = options.preferenceSet || DEFAULT_PREFERENCE_SET_ID;
+
+    const { data } = await this.knock.put(
+      `/v1/users/${userId}/preferences/${preferenceSetId}/workflows`,
+      workflowPreferences,
+    );
+
+    return data;
+  }
+
+  async setWorkflowPreferences(
+    userId: string,
+    workflowKey: string,
+    setting: WorkflowPreferenceSetting,
+    options: PreferenceOptions = {},
+  ): Promise<PreferenceSet> {
+    const preferenceSetId = options.preferenceSet || DEFAULT_PREFERENCE_SET_ID;
+
+    const { data } = await this.knock.put(
+      `/v1/users/${userId}/preferences/${preferenceSetId}/workflows/${workflowKey}`,
+      buildUpdateParam(setting),
+    );
+
+    return data;
+  }
+
+  async setCategoriesPreferences(
+    userId: string,
+    categoryPreferences: WorkflowPreferences,
+    options: PreferenceOptions = {},
+  ): Promise<PreferenceSet> {
+    const preferenceSetId = options.preferenceSet || DEFAULT_PREFERENCE_SET_ID;
+
+    const { data } = await this.knock.put(
+      `/v1/users/${userId}/preferences/${preferenceSetId}/categories`,
+      categoryPreferences,
+    );
+
+    return data;
+  }
+
+  async setCategoryPreferences(
+    userId: string,
+    categoryKey: string,
+    setting: WorkflowPreferenceSetting,
+    options: PreferenceOptions = {},
+  ): Promise<PreferenceSet> {
+    const preferenceSetId = options.preferenceSet || DEFAULT_PREFERENCE_SET_ID;
+
+    const { data } = await this.knock.put(
+      `/v1/users/${userId}/preferences/${preferenceSetId}/categories/${categoryKey}`,
+      buildUpdateParam(setting),
+    );
+
+    return data;
+  }
+
+  //
+  // Channel data
+  //
+
+  async getChannelData<T = CommonMetadata>(
+    userId: string,
+    channelId: string,
+  ): Promise<ChannelData<T>> {
     if (!userId || !channelId) {
       throw new Error(
         `Incomplete arguments. You must provide a 'userId' and a 'channelId'`,
@@ -47,11 +245,11 @@ export class Users {
     return data;
   }
 
-  async setChannelData(
+  async setChannelData<T = CommonMetadata>(
     userId: string,
     channelId: string,
     channelData: Record<string, string>,
-  ) {
+  ): Promise<ChannelData<T>> {
     if (!userId || !channelId) {
       throw new Error(
         `Incomplete arguments. You must provide a 'userId' and a 'channelId'`,

--- a/src/resources/users/index.ts
+++ b/src/resources/users/index.ts
@@ -129,6 +129,23 @@ export class Users {
     return data;
   }
 
+  async bulkSetPreferences(
+    userIds: string[],
+    preferenceSet: SetPreferencesProperties,
+    options: PreferenceOptions = {},
+  ): Promise<BulkOperation> {
+    const preferenceSetId = options.preferenceSet || DEFAULT_PREFERENCE_SET_ID;
+
+    const attrs = {
+      user_ids: userIds,
+      preferences: { ...preferenceSet, id: preferenceSetId },
+    };
+
+    const { data } = await this.knock.post(`/v1/users/bulk/preferences`, attrs);
+
+    return data;
+  }
+
   async setChannelTypesPreferences(
     userId: string,
     channelTypePreferences: ChannelTypePreferences,

--- a/src/resources/users/interfaces.ts
+++ b/src/resources/users/interfaces.ts
@@ -3,3 +3,29 @@ export interface IdentifyProperties {
   email?: string;
   [key: string]: any;
 }
+
+export interface User {
+  id: string;
+  name: string;
+  email: string;
+  // Knock system properties
+  phone_number?: string;
+  avatar?: string;
+  created_at?: string;
+  updated_at?: string;
+  // Can have anything else
+  [key: string]: any;
+}
+
+export interface BulkIdentifyUser extends IdentifyProperties {
+  id: string;
+}
+
+export interface UserFeedOptions {
+  page_size?: number;
+  after?: string;
+  before?: string;
+  source?: string;
+  tenant?: string;
+  status?: "unread" | "unseen" | "all";
+}

--- a/src/resources/workflows/interfaces.ts
+++ b/src/resources/workflows/interfaces.ts
@@ -1,6 +1,8 @@
+import { ObjectRef } from "../objects/interfaces";
+
 export interface TriggerWorkflowProperties {
-  actor: string;
-  recipients?: string[];
+  actor?: string | ObjectRef;
+  recipients?: string[] | ObjectRef[];
   cancellationKey?: string;
   tenant?: string;
   data?: {
@@ -9,7 +11,7 @@ export interface TriggerWorkflowProperties {
 }
 
 export interface CancelWorkflowProperties {
-  recipients?: string[];
+  recipients?: string[] | ObjectRef;
 }
 
 export interface WorkflowRun {


### PR DESCRIPTION
* Adds new `knock.objects` namespace and methods
* Adds new `knock.bulkOperations` namespace and method
* Deprecates `knock.preferences` in favor of `knock.users.*Preferences` methods
* Adds new `knock.users.bulk*` methods 