### PR TITLE
feat: preference conditions support

### DIFF
--- a/src/common/interfaces.ts
+++ b/src/common/interfaces.ts
@@ -34,7 +34,7 @@ type PageInfo = {
   before: string;
   after: string;
   page_size: number;
-}
+};
 
 export interface PaginatedResponse<T> {
   entries: T[];
@@ -45,4 +45,10 @@ export interface PaginationOptions {
   page_size?: number;
   after?: string;
   before?: string;
+}
+
+export interface Condition {
+  argument: string;
+  variable: string;
+  operator: string;
 }

--- a/src/resources/preferences/interfaces.ts
+++ b/src/resources/preferences/interfaces.ts
@@ -1,16 +1,17 @@
 import { ChannelType, Condition } from "../../common/interfaces";
 
-export type ChannelTypeSettings = {
+export type ConditionalPreferenceSettings = {
   conditions: Condition[];
 };
 
 export type ChannelTypePreferences = {
-  [K in ChannelType]?: boolean | ChannelTypeSettings;
+  [K in ChannelType]?: boolean | ConditionalPreferenceSettings;
 };
 
 export type WorkflowPreferenceSetting =
   | boolean
-  | { channel_types: ChannelTypePreferences };
+  | { channel_types: ChannelTypePreferences }
+  | ConditionalPreferenceSettings;
 
 export interface WorkflowPreferences {
   [key: string]: WorkflowPreferenceSetting;

--- a/src/resources/preferences/interfaces.ts
+++ b/src/resources/preferences/interfaces.ts
@@ -1,7 +1,11 @@
-import { ChannelType } from "../../common/interfaces";
+import { ChannelType, Condition } from "../../common/interfaces";
+
+export type ChannelTypeSettings = {
+  conditions: Condition[];
+};
 
 export type ChannelTypePreferences = {
-  [K in ChannelType]: boolean;
+  [K in ChannelType]?: boolean | ChannelTypeSettings;
 };
 
 export type WorkflowPreferenceSetting =

--- a/src/resources/users/index.ts
+++ b/src/resources/users/index.ts
@@ -13,10 +13,7 @@ import {
   WorkflowPreferences,
   WorkflowPreferenceSetting,
 } from "../preferences/interfaces";
-import {
-  ListMessagesOptions,
-  Message
-} from "../messages/interfaces";
+import { ListMessagesOptions, Message } from "../messages/interfaces";
 import {
   DEFAULT_PREFERENCE_SET_ID,
   buildUpdateParam,
@@ -283,7 +280,7 @@ export class Users {
   async setChannelData<T = CommonMetadata>(
     userId: string,
     channelId: string,
-    channelData: Record<string, string>,
+    channelData: Record<string, any>,
   ): Promise<ChannelData<T>> {
     if (!userId || !channelId) {
       throw new Error(
@@ -310,9 +307,7 @@ export class Users {
     filteringOptions: ListMessagesOptions = {},
   ): Promise<PaginatedResponse<Message>> {
     if (!userId) {
-      throw new Error(
-        `Incomplete arguments. You must provide a 'userId'`,
-      );
+      throw new Error(`Incomplete arguments. You must provide a 'userId'`);
     }
 
     const { data } = await this.knock.get(


### PR DESCRIPTION
* Adds support for setting `conditions` on preferences
* Fixes issue with channel data typing always being a `string` (should be `any`)
* Fixes issue where preferences required *all* channel types when setting channel types