### PR TITLE
fix: correct recipients typing

### DIFF
--- a/src/resources/workflows/interfaces.ts
+++ b/src/resources/workflows/interfaces.ts
@@ -1,8 +1,8 @@
 import { ObjectRef } from "../objects/interfaces";
 
 export interface TriggerWorkflowProperties<T = { [key: string]: any }> {
-  actor?: string | ObjectRef;
-  recipients?: string[] | ObjectRef[];
+  actor?: Actor;
+  recipients?: Recipient[];
   cancellationKey?: string;
   tenant?: string;
   data?: T;
@@ -15,3 +15,6 @@ export interface CancelWorkflowProperties {
 export interface WorkflowRun {
   workflow_run_id: string;
 }
+
+export type Recipient = string | ObjectRef;
+export type Actor = Recipient;


### PR DESCRIPTION
Recipients could only be a list of ids or a list of object references, after this update, it can be both!