### PR TITLE
feat: add message status endpoints and fix paginated response type

### DIFF
--- a/src/common/interfaces.ts
+++ b/src/common/interfaces.ts
@@ -36,8 +36,13 @@ type PageInfo = {
   page_size: number;
 };
 
-export interface PaginatedResponse<T> {
+export interface PaginatedFeedResponse<T> {
   entries: T[];
+  page_info: PageInfo;
+}
+
+export interface PaginatedResponse<T> {
+  items: T[];
   page_info: PageInfo;
 }
 

--- a/src/resources/messages/index.ts
+++ b/src/resources/messages/index.ts
@@ -1,16 +1,12 @@
-import {
-  PaginatedResponse,
-  PaginationOptions,
-} from "../../common/interfaces";
+import { PaginatedResponse, PaginationOptions } from "../../common/interfaces";
 import {
   Message,
   MessageContent,
   MessageEvent,
   ListMessagesOptions,
+  MessageEngagementStatus,
 } from "./interfaces";
-import {
-  Activity
-} from "../activities/interfaces";
+import { Activity } from "../activities/interfaces";
 import { Knock } from "../../knock";
 
 export class Messages {
@@ -24,9 +20,7 @@ export class Messages {
     return data;
   }
 
-  async get(
-    messageId: string
-  ): Promise<Message> {
+  async get(messageId: string): Promise<Message> {
     if (!messageId) {
       throw new Error(`Incomplete arguments. You must provide a 'messageId'`);
     }
@@ -35,9 +29,7 @@ export class Messages {
     return data;
   }
 
-  async getContent(
-    messageId: string
-  ): Promise<MessageContent> {
+  async getContent(messageId: string): Promise<MessageContent> {
     if (!messageId) {
       throw new Error(`Incomplete arguments. You must provide a 'messageId'`);
     }
@@ -48,7 +40,7 @@ export class Messages {
 
   async getEvents(
     messageId: string,
-    paginationOptions: PaginationOptions = {}
+    paginationOptions: PaginationOptions = {},
   ): Promise<PaginatedResponse<MessageEvent>> {
     if (!messageId) {
       throw new Error(`Incomplete arguments. You must provide a 'messageId'`);
@@ -56,7 +48,7 @@ export class Messages {
 
     const { data } = await this.knock.get(
       `/v1/messages/${messageId}/events`,
-      paginationOptions
+      paginationOptions,
     );
 
     return data;
@@ -72,8 +64,50 @@ export class Messages {
 
     const { data } = await this.knock.get(
       `/v1/messages/${messageId}/activities`,
-      paginationOptions
+      paginationOptions,
     );
+
+    return data;
+  }
+
+  async setStatus(
+    messageId: string,
+    status: MessageEngagementStatus,
+  ): Promise<Message> {
+    if (!messageId) {
+      throw new Error(`Incomplete arguments. You must provide a 'messageId'`);
+    }
+
+    const { data } = await this.knock.put(
+      `/v1/messages/${messageId}/${status}`,
+      {},
+    );
+
+    return data;
+  }
+
+  async deleteStatus(
+    messageId: string,
+    status: MessageEngagementStatus,
+  ): Promise<Message> {
+    if (!messageId) {
+      throw new Error(`Incomplete arguments. You must provide a 'messageId'`);
+    }
+
+    const { data } = await this.knock.delete(
+      `/v1/messages/${messageId}/${status}`,
+    );
+
+    return data;
+  }
+
+  async batchSetStatus(
+    messageIds: string[],
+    status: MessageEngagementStatus | "unseen" | "unread" | "unarchived",
+  ): Promise<Message[]> {
+    const { data } = await this.knock.post(`/v1/messages/batch/${status}`, {
+      message_ids: messageIds,
+    });
 
     return data;
   }

--- a/src/resources/messages/interfaces.ts
+++ b/src/resources/messages/interfaces.ts
@@ -47,6 +47,13 @@ export interface ListMessagesOptions extends PaginationOptions {
 type WorkflowSource = {
   version_id: string;
   key: string;
-}
+};
 
-type MessageStatus = "queued" | "sent" | "delivered" | "undelivered" | "not_sent";
+type MessageStatus =
+  | "queued"
+  | "sent"
+  | "delivered"
+  | "undelivered"
+  | "not_sent";
+
+export type MessageEngagementStatus = "seen" | "read" | "archived";

--- a/src/resources/users/index.ts
+++ b/src/resources/users/index.ts
@@ -2,6 +2,7 @@ import {
   ChannelData,
   ChannelType,
   CommonMetadata,
+  PaginatedFeedResponse,
   PaginatedResponse,
 } from "../../common/interfaces";
 import { BulkOperation } from "../bulk_operations/interfaces";
@@ -98,7 +99,7 @@ export class Users {
     userId: string,
     channelId: string,
     feedOptions: UserFeedOptions = {},
-  ) {
+  ): Promise<PaginatedFeedResponse<any>> {
     const { data } = await this.knock.get(
       `/v1/users/${userId}/feeds/${channelId}`,
       feedOptions,


### PR DESCRIPTION
* Adds new `setStatus` / `deleteStatus` / `batchSetStatus` method
* Fixes `PaginatedResponse` to return `items` and not `entries`
* Adds new `PaginatedFeedResponse` for `users.getFeed`