### PR TITLE
feat(kno-2630): add support for trigger_data filter

### DIFF
--- a/src/resources/messages/index.ts
+++ b/src/resources/messages/index.ts
@@ -3,6 +3,7 @@ import {
   Message,
   MessageContent,
   MessageEvent,
+  ListMessageActivitiesOptions,
   ListMessagesOptions,
   MessageEngagementStatus,
 } from "./interfaces";
@@ -56,7 +57,7 @@ export class Messages {
 
   async getActivities(
     messageId: string,
-    paginationOptions: PaginationOptions = {},
+    filteringOptions: ListMessageActivitiesOptions = {},
   ): Promise<PaginatedResponse<Activity>> {
     if (!messageId) {
       throw new Error(`Incomplete arguments. You must provide a 'messageId'`);
@@ -64,7 +65,7 @@ export class Messages {
 
     const { data } = await this.knock.get(
       `/v1/messages/${messageId}/activities`,
-      paginationOptions,
+      filteringOptions,
     );
 
     return data;

--- a/src/resources/messages/interfaces.ts
+++ b/src/resources/messages/interfaces.ts
@@ -42,6 +42,11 @@ export interface ListMessagesOptions extends PaginationOptions {
   tenant?: string;
   status?: MessageStatus[];
   channel_id?: string;
+  trigger_data?: Record<string, any>;
+}
+
+export interface ListMessageActivitiesOptions extends PaginationOptions {
+  trigger_data?: Record<string, any>;
 }
 
 type WorkflowSource = {

--- a/src/resources/users/interfaces.ts
+++ b/src/resources/users/interfaces.ts
@@ -29,6 +29,7 @@ export interface UserFeedOptions extends PaginationOptions {
   has_tenant?: boolean;
   archived?: "include" | "exclude" | "only";
   status?: "unread" | "unseen" | "all";
+  trigger_data?: Record<string, any>;
 }
 
 export interface ListUserOptions extends PaginationOptions {


### PR DESCRIPTION
Adds `trigger_data` filter to the following endpoints:
* Message list endpoint
* User messages endpoint
* Object messages endpoint
* Message activities endpoint
* User feed endpoint