### PR TITLE
fix: correct pagination types for usage

### DIFF
--- a/src/common/interfaces.ts
+++ b/src/common/interfaces.ts
@@ -28,7 +28,7 @@ export interface ChannelData<T = CommonMetadata> {
   data: T;
 }
 
-export interface SetChannelDataProperties { }
+export interface SetChannelDataProperties {}
 
 type PageInfo = {
   before: string;
@@ -36,12 +36,12 @@ type PageInfo = {
   page_size: number;
 };
 
-export interface PaginatedFeedResponse<T> {
+export interface PaginatedEntriesResponse<T> {
   entries: T[];
   page_info: PageInfo;
 }
 
-export interface PaginatedResponse<T> {
+export interface PaginatedItemsResponse<T> {
   items: T[];
   page_info: PageInfo;
 }

--- a/src/resources/messages/index.ts
+++ b/src/resources/messages/index.ts
@@ -1,4 +1,7 @@
-import { PaginatedResponse, PaginationOptions } from "../../common/interfaces";
+import {
+  PaginatedItemsResponse,
+  PaginationOptions,
+} from "../../common/interfaces";
 import {
   Message,
   MessageContent,
@@ -15,7 +18,7 @@ export class Messages {
 
   async list(
     filteringOptions: ListMessagesOptions = {},
-  ): Promise<PaginatedResponse<Message>> {
+  ): Promise<PaginatedItemsResponse<Message>> {
     const { data } = await this.knock.get("/v1/messages", filteringOptions);
 
     return data;
@@ -42,7 +45,7 @@ export class Messages {
   async getEvents(
     messageId: string,
     paginationOptions: PaginationOptions = {},
-  ): Promise<PaginatedResponse<MessageEvent>> {
+  ): Promise<PaginatedItemsResponse<MessageEvent>> {
     if (!messageId) {
       throw new Error(`Incomplete arguments. You must provide a 'messageId'`);
     }
@@ -58,7 +61,7 @@ export class Messages {
   async getActivities(
     messageId: string,
     filteringOptions: ListMessageActivitiesOptions = {},
-  ): Promise<PaginatedResponse<Activity>> {
+  ): Promise<PaginatedItemsResponse<Activity>> {
     if (!messageId) {
       throw new Error(`Incomplete arguments. You must provide a 'messageId'`);
     }

--- a/src/resources/objects/index.ts
+++ b/src/resources/objects/index.ts
@@ -2,8 +2,9 @@ import {
   ChannelData,
   CommonMetadata,
   SetChannelDataProperties,
-  PaginatedResponse,
+  PaginatedEntriesResponse,
   ChannelType,
+  PaginatedItemsResponse,
 } from "../../common/interfaces";
 import { Knock } from "../../knock";
 import {
@@ -57,7 +58,7 @@ export class Objects {
   async list<T = CommonMetadata>(
     collection: string,
     filteringOptions: ListObjectOptions = {},
-  ): Promise<PaginatedResponse<Object<T>>> {
+  ): Promise<PaginatedEntriesResponse<Object<T>>> {
     const { data } = await this.knock.get(
       `/v1/objects/${collection}`,
       filteringOptions,
@@ -150,7 +151,7 @@ export class Objects {
     collection: string,
     objectId: string,
     filteringOptions: ListMessagesOptions = {},
-  ): Promise<PaginatedResponse<Message>> {
+  ): Promise<PaginatedItemsResponse<Message>> {
     if (!collection || !objectId) {
       throw new Error(
         `Incomplete arguments. You must provide a 'collection' and 'objectId'`,
@@ -329,7 +330,7 @@ export class Objects {
     collection: string,
     objectId: string,
     options: ListObjectSubscriptionsOptions = {},
-  ): Promise<PaginatedResponse<ObjectSubscription>> {
+  ): Promise<PaginatedEntriesResponse<ObjectSubscription>> {
     const { data } = await this.knock.get(
       `/v1/objects/${collection}/${objectId}/subscriptions`,
       options,

--- a/src/resources/tenants/index.ts
+++ b/src/resources/tenants/index.ts
@@ -1,4 +1,7 @@
-import { CommonMetadata, PaginatedResponse } from "../../common/interfaces";
+import {
+  CommonMetadata,
+  PaginatedEntriesResponse,
+} from "../../common/interfaces";
 import { Knock } from "../../knock";
 import { Tenant, SetTenant, ListTenantsOptions } from "./interfaces";
 
@@ -7,7 +10,7 @@ export class Tenants {
 
   async list(
     filteringOptions: ListTenantsOptions = {},
-  ): Promise<PaginatedResponse<Tenant>> {
+  ): Promise<PaginatedEntriesResponse<Tenant>> {
     const { data } = await this.knock.get("/v1/tenants", filteringOptions);
 
     return data;

--- a/src/resources/users/index.ts
+++ b/src/resources/users/index.ts
@@ -2,8 +2,8 @@ import {
   ChannelData,
   ChannelType,
   CommonMetadata,
-  PaginatedFeedResponse,
-  PaginatedResponse,
+  PaginatedItemsResponse,
+  PaginatedEntriesResponse,
 } from "../../common/interfaces";
 import { BulkOperation } from "../bulk_operations/interfaces";
 import {
@@ -66,7 +66,7 @@ export class Users {
 
   async list(
     filteringOptions: ListUserOptions = {},
-  ): Promise<PaginatedResponse<User>> {
+  ): Promise<PaginatedEntriesResponse<User>> {
     const { data } = await this.knock.get(`/v1/users`, filteringOptions);
     return data;
   }
@@ -107,7 +107,7 @@ export class Users {
     userId: string,
     channelId: string,
     feedOptions: UserFeedOptions = {},
-  ): Promise<PaginatedFeedResponse<any>> {
+  ): Promise<PaginatedEntriesResponse<any>> {
     const { data } = await this.knock.get(
       `/v1/users/${userId}/feeds/${channelId}`,
       feedOptions,
@@ -338,7 +338,7 @@ export class Users {
   async getMessages(
     userId: string,
     filteringOptions: ListMessagesOptions = {},
-  ): Promise<PaginatedResponse<Message>> {
+  ): Promise<PaginatedItemsResponse<Message>> {
     if (!userId) {
       throw new Error(`Incomplete arguments. You must provide a 'userId'`);
     }


### PR DESCRIPTION
* We were incorrectly using `PaginatedResponse` for things that returned `entries`
* This PR introduces a new `PaginatedEntriesResponse` to encapsulate those vs `PaginatedItemsResponse`