### PR TITLE
feat(kno-3733): add support for subscription as recipient endpoints

### DIFF
--- a/src/resources/objects/index.ts
+++ b/src/resources/objects/index.ts
@@ -340,6 +340,19 @@ export class Objects {
     return data;
   }
 
+  async getSubscriptions(
+    collection: string,
+    objectId: string,
+    options: ListObjectSubscriptionsOptions = {},
+  ): Promise<PaginatedEntriesResponse<ObjectSubscription>> {
+    const { data } = await this.knock.get(
+      `/v1/objects/${collection}/${objectId}/subscriptions`,
+      {...options, mode: "recipient"},
+    );
+
+    return data;
+  }
+
   async addSubscriptions(
     collection: string,
     objectId: string,

--- a/src/resources/objects/interfaces.ts
+++ b/src/resources/objects/interfaces.ts
@@ -35,6 +35,7 @@ export interface ListObjectSubscriptionsOptions extends PaginationOptions {}
 
 export interface ObjectSubscription<T = CommonMetadata> {
   recipient: User | Object;
+  object: Object;
   properties: T;
   inserted_at: string;
   updated_at: string;

--- a/src/resources/users/index.ts
+++ b/src/resources/users/index.ts
@@ -371,4 +371,24 @@ export class Users {
 
     return data;
   }
+
+  //
+  // Subscriptions
+  //
+
+  async getSubscriptions(
+    userId: string,
+    filteringOptions: ListSchedulesProps = {},
+  ): Promise<PaginatedEntriesResponse<Schedule>> {
+    if (!userId) {
+      throw new Error(`Incomplete arguments. You must provide a 'userId'`);
+    }
+
+    const { data } = await this.knock.get(
+      `/v1/users/${userId}/subscriptions`,
+      filteringOptions,
+    );
+
+    return data;
+  }
 }


### PR DESCRIPTION
Adds support for fetching subscriptions as recipient for users and objects
