### PR TITLE
feat(KNO-4322): Add webhook channel type

### DIFF
--- a/src/common/interfaces.ts
+++ b/src/common/interfaces.ts
@@ -20,7 +20,7 @@ export interface UnprocessableEntityError {
 
 // Channel types supported in Knock
 // TODO: it would be great to pull this in from an external location
-export type ChannelType = "email" | "in_app_feed" | "sms" | "push" | "chat";
+export type ChannelType = "email" | "in_app_feed" | "sms" | "push" | "chat" | "http";
 
 export type CommonMetadata = Record<string, any>;
 


### PR DESCRIPTION
This PR handles this customer issue: https://knockcustomers.slack.com/archives/C033CKE13SS/p1694900805437269

We support all channel types except for `webhooks`, which means users can't set `ChannelTypePreferences ` for them.