### PR TITLE
feat(KNO-4645): Update schedule interfaces

### DIFF
--- a/src/resources/workflows/interfaces.ts
+++ b/src/resources/workflows/interfaces.ts
@@ -48,7 +48,7 @@ export interface CreateSchedulesProps {
   recipients: (Recipient | RecipientWithUpsert)[];
   actor?: Recipient | RecipientWithUpsert | null;
   scheduled_at?: string;
-  repeats: ScheduleRepeatProperties[];
+  repeats?: ScheduleRepeatProperties[];
   tenant?: string;
   data?: { [key: string]: any };
 }
@@ -75,7 +75,7 @@ export interface Schedule {
   workflow: string;
   data: { [key: string]: any };
   last_occurrence_at: string | null;
-  next_occurrence_at: string;
+  next_occurrence_at: string | null;
   inserted_at: string;
   updated_at: string;
   repeats: ScheduleRepeatProperties[];


### PR DESCRIPTION
* Updates the `CreateSchedulesProps` by setting `repeats` as nullable.
* Updates the `Schedule` by setting `next_occurrence_at` as nullable.

IMPORTANT: Do not merge until we ship one-off schedule support in Control: https://github.com/knocklabs/switchboard/pull/1719