### PR TITLE
feat(KNO-4998): Add tenant inline identification 

### DIFF
--- a/src/resources/tenants/index.ts
+++ b/src/resources/tenants/index.ts
@@ -23,7 +23,7 @@ export class Tenants {
 
   async set<T = CommonMetadata>(
     id: string,
-    tenantData: SetTenant,
+    tenantData: SetTenantProperties,
   ): Promise<Tenant<T>> {
     const { data } = await this.knock.put(`/v1/tenants/${id}`, tenantData);
     return data;

--- a/src/resources/tenants/index.ts
+++ b/src/resources/tenants/index.ts
@@ -3,7 +3,7 @@ import {
   PaginatedEntriesResponse,
 } from "../../common/interfaces";
 import { Knock } from "../../knock";
-import { Tenant, SetTenant, ListTenantsOptions } from "./interfaces";
+import { Tenant, ListTenantsOptions, SetTenantProperties } from "./interfaces";
 
 export class Tenants {
   constructor(readonly knock: Knock) {}

--- a/src/resources/tenants/interfaces.ts
+++ b/src/resources/tenants/interfaces.ts
@@ -1,4 +1,4 @@
-import { CommonMetadata, PaginationOptions } from "../../common/interfaces";
+import { CommonMetadata, PaginationOptions, SetChannelDataProperties } from "../../common/interfaces";
 import { SetPreferencesProperties } from "../preferences/interfaces";
 
 export interface TenantRef {
@@ -25,9 +25,12 @@ export interface Tenant<T = CommonMetadata> {
   updated_at: string;
 }
 
-export interface SetTenant {
+export interface SetTenantProperties {
   name?: string;
+  channelData?: SetChannelDataProperties;
   settings?: TenantSettings;
+  // Can have anything else
+  [key: string]: any;
 }
 
 export interface ListTenantsOptions extends PaginationOptions {

--- a/src/resources/workflows/interfaces.ts
+++ b/src/resources/workflows/interfaces.ts
@@ -1,12 +1,13 @@
 import { ObjectRef, SetObjectProperties } from "../objects/interfaces";
 import { IdentifyProperties } from "../users/interfaces";
 import { PaginationOptions } from "../../common/interfaces";
+import { SetTenantProperties, TenantRef } from "../tenants/interfaces";
 
 export interface TriggerWorkflowProperties<T = { [key: string]: any }> {
   actor?: Actor | ActorWithUpsert;
   recipients?: (Recipient | RecipientWithUpsert)[];
   cancellationKey?: string;
-  tenant?: string;
+  tenant?: Tenant | TenantWithUpsert;
   data?: T;
 }
 
@@ -49,7 +50,7 @@ export interface CreateSchedulesProps {
   actor?: Recipient | RecipientWithUpsert | null;
   scheduled_at?: string;
   repeats?: ScheduleRepeatProperties[];
-  tenant?: string;
+  tenant?: Tenant | TenantWithUpsert | null;
   data?: { [key: string]: any };
 }
 
@@ -86,12 +87,14 @@ export interface Schedule {
 
 export type Recipient = string | ObjectRef;
 export type Actor = Recipient;
+export type Tenant = string | TenantRef;
 
 export interface UserWithUpsert extends IdentifyProperties {
   id: string;
 }
 
 export type ObjectWithUpsert = ObjectRef & SetObjectProperties;
+export type TenantWithUpsert = TenantRef & SetTenantProperties;
 
 export type RecipientWithUpsert = UserWithUpsert | ObjectWithUpsert;
 export type ActorWithUpsert = RecipientWithUpsert;


### PR DESCRIPTION
This PR updates the following `interfaces`:
* TriggerWorkflowProperties
* CreateSchedulesProps
* UpdateSchedulesProps

Until now the `tenant` field in these interfaces was a simple `string`, but with these changes we now allow users to use a `Tenant` or `TenantWithUpsert` so they can inline identify tenants.
