### PR TITLE
fix(kno-5070): add headers to put request

### DIFF
--- a/src/knock.ts
+++ b/src/knock.ts
@@ -127,6 +127,11 @@ class Knock {
     try {
       return await this.client.put(path, {
         params: options.query,
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json",
+          ...options.headers,
+        },
         body: entity,
       });
     } catch (error) {

--- a/src/knock.ts
+++ b/src/knock.ts
@@ -56,6 +56,8 @@ class Knock {
       headers: {
         Authorization: `Bearer ${this.key}`,
         "User-Agent": `knocklabs/node@${version}`,
+        "Content-Type": "application/json",
+        Accept: "application/json",
       },
     });
   }
@@ -107,8 +109,6 @@ class Knock {
       return await this.client.post(path, {
         params: options.query,
         headers: {
-          "Content-Type": "application/json",
-          Accept: "application/json",
           ...options.headers,
         },
         body: entity,
@@ -128,8 +128,6 @@ class Knock {
       return await this.client.put(path, {
         params: options.query,
         headers: {
-          "Content-Type": "application/json",
-          Accept: "application/json",
           ...options.headers,
         },
         body: entity,


### PR DESCRIPTION
The `PUT` method was missing these headers that are necessary for a successful request.