### PR TITLE
fix: handle single error responses

### DIFF
--- a/src/knock.ts
+++ b/src/knock.ts
@@ -172,7 +172,10 @@ class Knock {
           throw new BadRequestException(code, message, requestID);
         }
         case 422: {
-          const { errors } = data;
+          const errors = Array.isArray(data.errors)
+            ? data.errors
+            : [data.errors];
+
           throw new UnprocessableEntityException(errors, requestID);
         }
         case 404: {

--- a/src/knock.ts
+++ b/src/knock.ts
@@ -172,7 +172,10 @@ class Knock {
           throw new BadRequestException(code, message, requestID);
         }
         case 422: {
-          const errors = Array.isArray(data.errors)
+          // Format errors as an array before passing to exception constructor
+          const errors = !data.errors
+            ? []
+            : Array.isArray(data.errors)
             ? data.errors
             : [data.errors];
 


### PR DESCRIPTION
## Description

The API typically returns an array of error messages but in some cases, returns a single error. This update checks if errors is an array or single instance. If it's a single error, it wraps it in an array so that formatting the error message works correctly in `UnprocessableEntityException`

Resolves #47 