### PR TITLE
fix: format url query params as array rather than comma-separated list

### DIFF
--- a/src/common/fetchClient.ts
+++ b/src/common/fetchClient.ts
@@ -91,9 +91,12 @@ export default class FetchClient {
     const url = new URL(this.config.baseURL + path);
 
     if (params) {
-      Object.entries(params).forEach(([key, value]) =>
-        url.searchParams.append(key, value),
-      );
+      Object.entries(params).forEach(([key, value]) => {
+        // Send array values as URL-encoded arrays rather than the default comma-separated list
+        // e.g. key=[1,2,3] instead of key=1,2,3
+        const paramValue = Array.isArray(value) ? JSON.stringify(value) : value;
+        url.searchParams.append(key, paramValue);
+      });
     }
 
     return url;

--- a/src/common/fetchClient.ts
+++ b/src/common/fetchClient.ts
@@ -92,10 +92,15 @@ export default class FetchClient {
 
     if (params) {
       Object.entries(params).forEach(([key, value]) => {
-        // Send array values as URL-encoded arrays rather than the default comma-separated list
-        // e.g. key=[1,2,3] instead of key=1,2,3
-        const paramValue = Array.isArray(value) ? JSON.stringify(value) : value;
-        url.searchParams.append(key, paramValue);
+        // Send array values as individual values instead of a comma separated list
+        // e.g. key[]=1&key[]=2&key[]=3 instead of key=1,2,3
+        if (Array.isArray(value)) {
+          for (const val of value) {
+            url.searchParams.append(`${key}[]`, val);
+          }
+        } else {
+          url.searchParams.append(key, value);
+        }
       });
     }
 

--- a/test/resources/workflows.test.ts
+++ b/test/resources/workflows.test.ts
@@ -1,0 +1,50 @@
+import { afterAll, afterEach, beforeAll, describe, test, expect } from "vitest";
+import { setupServer } from "msw/node";
+import { HttpResponse, http } from "msw";
+import { Knock } from "../../src/knock";
+import { ListSchedulesProps } from "../../src/resources/workflows/interfaces";
+
+const restHandlers = [
+  http.get("http://api.knock.test/v1/schedules", () => {
+    return HttpResponse.json({
+      entries: [],
+      page_info: {
+        __typename: "PageInfo",
+        after: null,
+        before: null,
+        page_size: 50,
+        total_count: 0,
+      },
+    });
+  }),
+];
+
+const server = setupServer(...restHandlers);
+
+const knock = new Knock("sk_test_12345", {
+  host: "http://api.knock.test",
+});
+
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+
+afterAll(() => server.close());
+
+afterEach(() => server.resetHandlers());
+
+describe("schedules", () => {
+  test("it can list schedules", async () => {
+    const params: ListSchedulesProps = {
+      recipients: ["1", "2", "3"],
+    };
+    const { url } = await knock.get("/v1/schedules", {
+      ...params,
+      workflow: "test-workflow",
+    });
+
+    // Formats recipients list as a URL-encoded array
+    // 'http://api.knock.test/v1/schedules?recipients=["1","2","3"]&workflow=test-workflow'
+    expect(url).toBe(
+      "http://api.knock.test/v1/schedules?recipients=%5B%221%22%2C%222%22%2C%223%22%5D&workflow=test-workflow",
+    );
+  });
+});

--- a/test/resources/workflows.test.ts
+++ b/test/resources/workflows.test.ts
@@ -42,9 +42,9 @@ describe("schedules", () => {
     });
 
     // Formats recipients list as a URL-encoded array
-    // 'http://api.knock.test/v1/schedules?recipients=["1","2","3"]&workflow=test-workflow'
+    // 'http://api.knock.test/v1/schedules?recipients[]=1&recipients[]=2&recipients[]=3&workflow=test-workflow'
     expect(url).toBe(
-      "http://api.knock.test/v1/schedules?recipients=%5B%221%22%2C%222%22%2C%223%22%5D&workflow=test-workflow",
+      "http://api.knock.test/v1/schedules?recipients%5B%5D=1&recipients%5B%5D=2&recipients%5B%5D=3&workflow=test-workflow",
     );
   });
 });


### PR DESCRIPTION
Phoenix expects array values in query params to be an array rather than a comma-separated list. This updated the fetch client so that it formats array params correctly.