### PR TITLE
chore(kno-5606): add recipients filter param to objects subscriptions

### DIFF
--- a/src/resources/objects/index.ts
+++ b/src/resources/objects/index.ts
@@ -12,6 +12,7 @@ import {
   BulkAddSubscriptionsOption,
   BulkSetObjectOption,
   DeleteObjectSubscriptionProperties,
+  GetObjectSubscriptionsOptions,
   ListObjectOptions,
   ListObjectSubscriptionsOptions,
   Object,
@@ -353,7 +354,7 @@ export class Objects {
   async getSubscriptions(
     collection: string,
     objectId: string,
-    options: ListObjectSubscriptionsOptions = {},
+    options: GetObjectSubscriptionsOptions = {},
   ): Promise<PaginatedEntriesResponse<ObjectSubscription>> {
     const {
       data,

--- a/src/resources/objects/interfaces.ts
+++ b/src/resources/objects/interfaces.ts
@@ -40,7 +40,9 @@ export interface ListObjectOptions extends PaginationOptions {
   name?: string;
 }
 
-export interface ListObjectSubscriptionsOptions extends PaginationOptions {}
+export interface ListObjectSubscriptionsOptions extends PaginationOptions {
+  recipients?: Recipient[];
+}
 
 export interface ObjectSubscription<T = CommonMetadata> {
   recipient: User | Object;

--- a/src/resources/objects/interfaces.ts
+++ b/src/resources/objects/interfaces.ts
@@ -44,6 +44,8 @@ export interface ListObjectSubscriptionsOptions extends PaginationOptions {
   recipients?: Recipient[];
 }
 
+export interface GetObjectSubscriptionsOptions extends PaginationOptions {}
+
 export interface ObjectSubscription<T = CommonMetadata> {
   recipient: User | Object;
   object: Object;


### PR DESCRIPTION
Updates `ListObjectSubscriptionsOptions` to support new `recipients` filter param