### PR TITLE
send delete entity in request body rather than params

### DIFF
--- a/src/knock.ts
+++ b/src/knock.ts
@@ -167,7 +167,7 @@ class Knock {
   async delete(path: string, entity: any = {}): Promise<FetchResponse> {
     try {
       return await this.client.delete(path, {
-        params: entity,
+        body: entity,
       });
     } catch (error) {
       this.handleErrorResponse(path, error);


### PR DESCRIPTION
the `DeleteSubscriptionProperties` passed to `knock.objects.deleteSubscriptions` should be used in the DELETE request's body rather than the query parameters. 