### PR TITLE
fix: add interacted and link_clicked to engagement statuses

### DIFF
--- a/src/resources/messages/index.ts
+++ b/src/resources/messages/index.ts
@@ -76,7 +76,7 @@ export class Messages {
 
   async setStatus(
     messageId: string,
-    status: MessageEngagementStatus,
+    status: Exclude<MessageEngagementStatus, "link_clicked">,
   ): Promise<Message> {
     if (!messageId) {
       throw new Error(`Incomplete arguments. You must provide a 'messageId'`);
@@ -92,7 +92,7 @@ export class Messages {
 
   async deleteStatus(
     messageId: string,
-    status: MessageEngagementStatus,
+    status: Exclude<MessageEngagementStatus, "link_clicked">,
   ): Promise<Message> {
     if (!messageId) {
       throw new Error(`Incomplete arguments. You must provide a 'messageId'`);
@@ -107,7 +107,11 @@ export class Messages {
 
   async batchSetStatus(
     messageIds: string[],
-    status: MessageEngagementStatus | "unseen" | "unread" | "unarchived",
+    status:
+      | Exclude<MessageEngagementStatus, "link_clicked">
+      | "unseen"
+      | "unread"
+      | "unarchived",
   ): Promise<Message[]> {
     const { data } = await this.knock.post(`/v1/messages/batch/${status}`, {
       message_ids: messageIds,

--- a/src/resources/messages/interfaces.ts
+++ b/src/resources/messages/interfaces.ts
@@ -61,4 +61,9 @@ type MessageStatus =
   | "undelivered"
   | "not_sent";
 
-export type MessageEngagementStatus = "seen" | "read" | "archived";
+export type MessageEngagementStatus =
+  | "seen"
+  | "read"
+  | "archived"
+  | "interacted"
+  | "link_clicked";


### PR DESCRIPTION
* adds interacted and link_clicked to engagement statuses
* excludes link_clicked from updating status and deleting status