### PR TITLE
fix: filter undefined values when creating the query url

### DIFF
--- a/src/common/fetchClient.ts
+++ b/src/common/fetchClient.ts
@@ -97,6 +97,9 @@ export default class FetchClient {
     function appendParams(key: string, value: any, parentKey?: string) {
       const fullKey = parentKey ? `${parentKey}[${key}]` : key;
 
+      // Skip undefined values
+      if (value === undefined) return url;
+
       if (
         typeof value === "object" &&
         value !== null &&

--- a/src/common/fetchClient.ts
+++ b/src/common/fetchClient.ts
@@ -98,7 +98,7 @@ export default class FetchClient {
       const fullKey = parentKey ? `${parentKey}[${key}]` : key;
 
       // Skip undefined values
-      if (value === undefined) return url;
+      if (value === undefined) return;
 
       if (
         typeof value === "object" &&


### PR DESCRIPTION
Undefined values were being included in the query url which was causing validation errors. This PR skips undefined values when building the query url. 