### PR TITLE
chore: add deprecated jsdoc for notify

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@knocklabs/node",
-  "version": "0.6.11",
+  "version": "0.6.12",
   "description": "Library for interacting with the Knock API",
   "homepage": "https://github.com/knocklabs/knock-node",
   "author": "@knocklabs",

--- a/src/knock.ts
+++ b/src/knock.ts
@@ -69,7 +69,12 @@ class Knock {
     });
   }
 
-  // Delegate the notify function to the workflows trigger
+
+  /**
+   * Delegate the notify function to the workflows trigger
+   *
+   * @deprecated use workflows.trigger instead.
+   */
   async notify(
     workflowKey: string,
     properties: TriggerWorkflowProperties,

--- a/src/knock.ts
+++ b/src/knock.ts
@@ -69,7 +69,6 @@ class Knock {
     });
   }
 
-
   /**
    * Delegate the notify function to the workflows trigger
    *


### PR DESCRIPTION
Adds a deprecated annotation to the `notify` method