### PR TITLE
chore: update list message opts interface

### DIFF
--- a/src/resources/messages/interfaces.ts
+++ b/src/resources/messages/interfaces.ts
@@ -43,6 +43,7 @@ export interface ListMessagesOptions extends PaginationOptions {
   status?: MessageStatus[];
   channel_id?: string;
   trigger_data?: Record<string, any>;
+  workflow_categories?: String[];
 }
 
 export interface ListMessageActivitiesOptions extends PaginationOptions {


### PR DESCRIPTION
Someone called out in Slack that this interface doesn't support the `workflow_categories` string array param available on the API, so I added it. My assumption here is that passing it to `knock.get` will work the same as `MessageStatus[]` so I just added the necessary typing.