### PR TITLE
fix: update preference set types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@knocklabs/node",
-  "version": "0.6.13",
+  "version": "0.6.14",
   "description": "Library for interacting with the Knock API",
   "homepage": "https://github.com/knocklabs/knock-node",
   "author": "@knocklabs",

--- a/src/resources/preferences/interfaces.ts
+++ b/src/resources/preferences/interfaces.ts
@@ -25,9 +25,9 @@ export interface SetPreferencesProperties {
 
 export interface PreferenceSet {
   id: string;
-  categories: WorkflowPreferences;
-  workflows: WorkflowPreferences;
-  channel_types: ChannelTypePreferences;
+  categories: WorkflowPreferences | null;
+  workflows: WorkflowPreferences | null;
+  channel_types: ChannelTypePreferences | null;
 }
 
 export interface PreferenceOptions {


### PR DESCRIPTION
Marks categories, workflows, and channel_types as nullable which matches the behavior of the API to match the JS client SDK.