### PR TITLE
fix: update list message types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@knocklabs/node",
-  "version": "0.6.14",
+  "version": "0.6.15",
   "description": "Library for interacting with the Knock API",
   "homepage": "https://github.com/knocklabs/knock-node",
   "author": "@knocklabs",

--- a/src/resources/messages/interfaces.ts
+++ b/src/resources/messages/interfaces.ts
@@ -41,9 +41,15 @@ export interface ListMessagesOptions extends PaginationOptions {
   source?: string;
   tenant?: string;
   status?: MessageStatus[];
+  engagement_status?: MessageEngagementStatusFilter[];
   channel_id?: string;
+  message_ids?: string[];
   trigger_data?: Record<string, any>;
   workflow_categories?: String[];
+  "inserted_at.gt"?: string;
+  "inserted_at.gte"?: string;
+  "inserted_at.lt"?: string;
+  "inserted_at.lte"?: string;
 }
 
 export interface ListMessageActivitiesOptions extends PaginationOptions {
@@ -60,7 +66,9 @@ type MessageStatus =
   | "sent"
   | "delivered"
   | "undelivered"
-  | "not_sent";
+  | "not_sent"
+  | "delivery_attempted"
+  | "bounced";
 
 export type MessageEngagementStatus =
   | "seen"
@@ -68,3 +76,9 @@ export type MessageEngagementStatus =
   | "archived"
   | "interacted"
   | "link_clicked";
+
+type MessageEngagementStatusFilter =
+  | MessageEngagementStatus
+  | "unseen"
+  | "unread"
+  | "unarchived";


### PR DESCRIPTION
Adds engagement status, date filters, and message id query params to match what the API supports: https://docs.knock.app/reference#get-user-messages