### PR TITLE
chore(KNO-9366): add new-issue-comment workflow

### DIFF
--- a/.github/workflows/new-issue-comment.yml
+++ b/.github/workflows/new-issue-comment.yml
@@ -1,0 +1,16 @@
+name: New Issue Comment
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  notify-slack:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send issue comment to Slack workflow
+        uses: slackapi/slack-github-action@v2.1.1
+        with:
+          payload-delimiter: "."
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: webhook-trigger


### PR DESCRIPTION
This follows the guidance in [Slack’s *Sending data via a webhook to start a Slack workflow*](https://tools.slack.dev/slack-github-action/sending-techniques/sending-data-webhook-slack-workflow/) documentation.