### PR TITLE
fix: properly serialize arrays of objects in query params

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -329,7 +329,7 @@ export class Knock {
   }
 
   protected stringifyQuery(query: Record<string, unknown>): string {
-    return qs.stringify(query, { arrayFormat: 'brackets' });
+    return qs.stringify(query, { arrayFormat: 'indices' });
   }
 
   private getUserAgent(): string {

--- a/tests/qs/stringify.test.ts
+++ b/tests/qs/stringify.test.ts
@@ -2230,3 +2230,14 @@ describe('stringifies empty keys', function () {
     );
   });
 });
+
+describe('arrays of objects formatting', function () {
+  test('formats arrays of objects using indices', function () {
+    expect(
+      stringify(
+        { objects: [{ id: 1, collection: 'teams' }] },
+        { encodeValuesOnly: true, arrayFormat: 'indices' },
+      ),
+    ).toBe('objects[0][id]=1&objects[0][collection]=teams');
+  });
+});


### PR DESCRIPTION
Serializes arrays of objects using "indices". See `querystring` lib for more details: https://github.com/ljharb/qs?tab=readme-ov-file#stringifying. This should match the format expected by our API for these types of params.

https://linear.app/knock/issue/KNO-9422/sdk-bug-in-node-sdks-list-user-subscriptions