### PR TITLE
chore(KNO-9521): add CJS instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,35 +243,35 @@ The SDK provides functionality to sign authentication tokens for client-side req
 
 #### Installation
 
-By default, this SDK uses [`jose`](https://github.com/panva/jose) to sign JWTs. The latest version of `jose` only supports ESM, so if your project is built using CJS, and you're not already running [a version of Node.js that supports loading ES modules using `require`](https://nodejs.org/api/modules.html#loading-ecmascript-modules-using-require), you'll need to take the following additional steps to build with a CJS-compatible version of `jose`.
+By default, this SDK uses [`jose`](https://github.com/panva/jose) to sign JWTs. The latest version of `jose` only supports ESM, so if your project is built using CJS, and you're _not_ already running [a version of Node.js that supports loading ES modules using `require`](https://nodejs.org/api/modules.html#loading-ecmascript-modules-using-require), you'll need to take the following additional step to build with a CJS-compatible version of `jose`:
 
-If you're using `npm`, add the `overrides` option to your `package.json` file to install `jose` v5:
-
-```json
-{
-  "dependencies": {
-    "@knocklabs/node": "^1",
-    "jose": "^5.10.0"
-  },
-  "overrides": {
-    "jose": "^5.10.0"
+- If you're using `npm`, add the `overrides` option to your `package.json` file to install `jose` v5:
+  
+  ```json
+  {
+    "dependencies": {
+      "@knocklabs/node": "^1",
+      "jose": "^5.10.0"
+    },
+    "overrides": {
+      "jose": "^5.10.0"
+    }
   }
-}
-```
+  ```
 
-If you're using `yarn`, add the `resolutions` option to your `package.json` file to install `jose` v5:
+- If you're using `yarn`, add the `resolutions` option to your `package.json` file to install `jose` v5:
 
-```json
-{
-  "dependencies": {
-    "@knocklabs/node": "^1",
-    "jose": "^5.10.0"
-  },
-  "resolutions": {
-    "jose": "^5.10.0"
+  ```json
+  {
+    "dependencies": {
+      "@knocklabs/node": "^1",
+      "jose": "^5.10.0"
+    },
+    "resolutions": {
+      "jose": "^5.10.0"
+    }
   }
-}
-```
+  ```
 
 #### Basic Usage
 

--- a/README.md
+++ b/README.md
@@ -239,16 +239,38 @@ endpoints, params, or response properties, the library can still be used.
 
 ### JWT Token Signing
 
-The SDK provides functionality to sign authentication tokens for client-side requests, such as for in-app feeds. This feature requires the `jose` package as an optional peer dependency.
+The SDK provides functionality to sign authentication tokens for client-side requests, such as for in-app feeds.
 
 #### Installation
 
-If you plan to use JWT token signing, you'll need to install `jose`:
+By default, this SDK uses [`jose`](https://github.com/panva/jose) to sign JWTs. The latest version of `jose` only supports ESM, so if your project is built using CJS, and you're not already running [a version of Node.js that supports loading ES modules using `require`](https://nodejs.org/api/modules.html#loading-ecmascript-modules-using-require), you'll need to take the following additional steps to build with a CJS-compatible version of `jose`.
 
-```sh
-npm install jose
-# or
-yarn add jose
+If you're using `npm`, add the `overrides` option to your `package.json` file to install `jose` v5:
+
+```json
+{
+  "dependencies": {
+    "@knocklabs/node": "^1",
+    "jose": "^5.10.0"
+  },
+  "overrides": {
+    "jose": "^5.10.0"
+  }
+}
+```
+
+If you're using `yarn`, add the `resolutions` option to your `package.json` file to install `jose` v5:
+
+```json
+{
+  "dependencies": {
+    "@knocklabs/node": "^1",
+    "jose": "^5.10.0"
+  },
+  "resolutions": {
+    "jose": "^5.10.0"
+  }
+}
 ```
 
 #### Basic Usage


### PR DESCRIPTION
This PR updates `README.md` to include instructions for installing a CJS-compatible version of `jose` when using a version of Node.js that does not support loading ES modules using `require`.