### PR TITLE
fix(kno-9922): move custom query serialization to src/lib

### DIFF
--- a/src/internal/utils/query.ts
+++ b/src/internal/utils/query.ts
@@ -1,31 +1,7 @@
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
-import * as qs from '../qs/stringify';
-
-/**
- * Stringify query parameters with smart array handling:
- * 1. Simple arrays → 'brackets' format: `tags[]=tag1&tags[]=tag2`
- * 2. Arrays of objects → 'indices' format: `objects[0][id]=1&objects[0][collection]=teams`
- */
-export function stringifyQuery(query: object | Record<string, unknown>): string {
-  const record = query as Record<string, unknown>;
-  const objectArrays: Record<string, unknown> = {};
-  const otherParams: Record<string, unknown> = {};
-
-  for (const key in record) {
-    const value = record[key];
-    if (Array.isArray(value) && value.length > 0 && typeof value[0] === 'object' && value[0] !== null) {
-      objectArrays[key] = value;
-    } else {
-      otherParams[key] = value;
-    }
-  }
-
-  const otherParamsString = qs.stringify(otherParams, { arrayFormat: 'brackets' });
-  const objectArraysString = qs.stringify(objectArrays, { arrayFormat: 'indices' });
-
-  if (otherParamsString && objectArraysString) {
-    return `${otherParamsString}&${objectArraysString}`;
-  }
-  return otherParamsString || objectArraysString;
-}
+// NOTE: The custom query-string serialization lives in `src/lib/stringifyQuery.ts`,
+// which the Stainless generator never modifies. This file only re-exports it so the
+// generated client (and the generated tests that import from here) pick it up. If a
+// regeneration overwrites this file, re-add this one-line re-export. See KNO-9922.
+export { stringifyQuery } from '../../lib/stringifyQuery';

--- a/src/lib/stringifyQuery.ts
+++ b/src/lib/stringifyQuery.ts
@@ -1,0 +1,41 @@
+import * as qs from '../internal/qs/stringify';
+
+/**
+ * Stringify query parameters with smart array handling:
+ *
+ * 1. Simple arrays (primitives) → 'brackets' format: `tags[]=tag1&tags[]=tag2`
+ * 2. Arrays of objects → 'indices' format: `objects[0][id]=1&objects[0][collection]=teams`
+ *
+ * The Knock API (Phoenix) expects object-array query params in indexed form
+ * (`objects[0][id]`), which Plug decodes into a keyed list. Primitive arrays must
+ * stay in bracket form (`include[]`) — indexed primitives (`include[0]`) get
+ * misparsed as a map `{ "0": ... }` and cause 422s. `qs` only supports a single
+ * global `arrayFormat`, so we partition the params and serialize each group with
+ * the format it needs.
+ *
+ * This lives in `src/lib/`, which the Stainless generator never modifies (see
+ * CONTRIBUTING.md), so the behavior survives regeneration of the generated query
+ * util. See KNO-9922.
+ */
+export function stringifyQuery(query: object | Record<string, unknown>): string {
+  const record = query as Record<string, unknown>;
+  const objectArrays: Record<string, unknown> = {};
+  const otherParams: Record<string, unknown> = {};
+
+  for (const key in record) {
+    const value = record[key];
+    if (Array.isArray(value) && value.length > 0 && typeof value[0] === 'object' && value[0] !== null) {
+      objectArrays[key] = value;
+    } else {
+      otherParams[key] = value;
+    }
+  }
+
+  const otherParamsString = qs.stringify(otherParams, { arrayFormat: 'brackets' });
+  const objectArraysString = qs.stringify(objectArrays, { arrayFormat: 'indices' });
+
+  if (otherParamsString && objectArraysString) {
+    return `${otherParamsString}&${objectArraysString}`;
+  }
+  return otherParamsString || objectArraysString;
+}


### PR DESCRIPTION
This aims to fix the failing CI in the current [release PR](https://github.com/knocklabs/knock-node/pull/156), by restoring custom code/fix that got dropped in a recent commit be1705d by Stainless when it regenerated the `src/internal/utils/query.ts` helper. 

I think the issue was that we applied the custom code from November directly in the generated file, which made it more vulnerable to be overwritten by the generator. 

Per Stainless docs, `src/lib/` is never touched by the generator, so we move the actual logic there (src/lib/stringifyQuery.ts) and have the generated util re-export it, that way the substantive code is in the generator-safe zone. AFAIK Stainless applies custom code as a three way merge so I believe (hope) this fix survives regenerations (to be seen).

**IMPORTANT to note:** Back in November we only applied the custom fix in `knock-node`. So the way other SDKs handle array params is not consistent across (e.g. knock-python, knock-go, etc), which means those SDKs are / always have been broken so we likely need to port the same custom code/fix there.

---
Full timeline: 
* August 2025 (#117): 
  * We applied custom code to override the `arrayFormat` option in the query string helper to use 'indices' instead of 'brackets'. 
  * Based on how Phoenix/Plug handles array params, this fixed things for complex arrays (e.g. array of objects) but at the same time broke it for simple arrays (e.g. array of ids)
* November 2025 (#141): 
  * We applied different custom code to replace the default `stringifyQuery` helper with a bespoke implementation that used both 'indices' and 'brackets' options depending on the array item data type
  * This fixed for both cases (simple arrays, and complex arrays)
* May 2026 (https://github.com/stainless-sdks/knock-typescript/pull/9):
  * A merge conflict happened after Stainless regenerates that file, which removed the custom code fix from November. 
  * This got merged last week by the Stainless team as we kicked off the migration process, which resulted in the failing CI. 
